### PR TITLE
DAMIEN-192 Replace course start/end dates with evaluation period

### DIFF
--- a/damien/merged/section.py
+++ b/damien/merged/section.py
@@ -23,6 +23,7 @@ SOFTWARE AND ACCOMPANYING DOCUMENTATION, IF ANY, PROVIDED HEREUNDER IS PROVIDED
 ENHANCEMENTS, OR MODIFICATIONS.
 """
 
+from datetime import timedelta
 from itertools import groupby
 import re
 
@@ -47,6 +48,13 @@ class Section:
         self.instruction_format = loch_rows[0].instruction_format
         self.section_num = loch_rows[0].section_num
         self.course_title = loch_rows[0].course_title
+
+        self.start_date = min((r['meeting_start_date'] for r in loch_rows if r['meeting_start_date']), default=None)
+        self.end_date = max((r['meeting_end_date'] for r in loch_rows if r['meeting_end_date']), default=None)
+        if self.start_date and self.end_date and self.end_date - self.start_date < timedelta(days=90):
+            self.modular = True
+        else:
+            self.modular = False
 
         self.loch_rows = loch_rows
         self.evaluations = evaluations
@@ -169,6 +177,7 @@ class Section:
             'instructionFormat': self.instruction_format,
             'sectionNumber': self.section_num,
             'courseTitle': self.course_title,
+            'modular': self.modular,
         }
         if self.cross_listed_with:
             feed['crossListedWith'] = self.cross_listed_with

--- a/damien/models/evaluation.py
+++ b/damien/models/evaluation.py
@@ -358,9 +358,10 @@ class Evaluation(Base):
     def set_start_date(self, loch_rows, foreign_dept_evaluations, saved_evaluation):
         if saved_evaluation and saved_evaluation.start_date:
             self.start_date = saved_evaluation.start_date
-            for fde in foreign_dept_evaluations:
-                if fde.start_date and fde.start_date != self.start_date:
-                    self.mark_conflict(fde, 'startDate', safe_strftime(fde.start_date, '%Y-%m-%d'))
+            # TODO remove start date as independently tracked value
+            # for fde in foreign_dept_evaluations:
+            #    if fde.start_date and fde.start_date != self.start_date:
+            #         self.mark_conflict(fde, 'startDate', safe_strftime(fde.start_date, '%Y-%m-%d'))
         else:
             for fde in foreign_dept_evaluations:
                 if fde.start_date:

--- a/package-lock.json
+++ b/package-lock.json
@@ -4654,6 +4654,16 @@
         "assert-plus": "^1.0.0"
       }
     },
+    "date-fns": {
+      "version": "2.28.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.28.0.tgz",
+      "integrity": "sha512-8d35hViGYx/QH0icHYCeLmsLmMUheMmTyV9Fcm6gvNwdw31yXXH+O85sOBJ+OLnLQMKZowvpKb6FgMIQjcpvQw=="
+    },
+    "date-fns-tz": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/date-fns-tz/-/date-fns-tz-1.3.0.tgz",
+      "integrity": "sha512-r6ye6PmGEvkF467/41qzU71oGwv9kHTnV3vtSZdyV6VThwPID47ZH7FtR7zQWrhgOUWkYySm2ems2w6ZfNUqoA=="
+    },
     "de-indent": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/de-indent/-/de-indent-1.0.2.tgz",
@@ -6286,7 +6296,7 @@
       }
     },
     "fork-ts-checker-webpack-plugin-v5": {
-      "version": "npm:fork-ts-checker-webpack-plugin-v5@5.2.1",
+      "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/fork-ts-checker-webpack-plugin/-/fork-ts-checker-webpack-plugin-5.2.1.tgz",
       "integrity": "sha512-SVi+ZAQOGbtAsUWrZvGzz38ga2YqjWvca1pXQFUArIVXqli0lLoDQ8uS0wg0kSpcwpZmaW5jVCZXQebkyUQSsw==",
       "dev": true,
@@ -6459,8 +6469,7 @@
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
           "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "yallist": {
           "version": "4.0.0",
@@ -12332,6 +12341,17 @@
       "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
       "dev": true
     },
+    "v-calendar": {
+      "version": "2.3.4",
+      "resolved": "https://registry.npmjs.org/v-calendar/-/v-calendar-2.3.4.tgz",
+      "integrity": "sha512-jH9cCuryt7++LWkHE4zvkqORQYUmmfLwhYxaDzndTrd3hWyLtm3WGyfanc++PEqchTkPP31VewFTXqlSf3Gk7Q==",
+      "requires": {
+        "core-js": "^3.15.2",
+        "date-fns": "^2.22.1",
+        "date-fns-tz": "^1.1.4",
+        "lodash": "^4.17.21"
+      }
+    },
     "v8-compile-cache": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.3.0.tgz",
@@ -12479,7 +12499,7 @@
       }
     },
     "vue-loader-v16": {
-      "version": "npm:vue-loader-v16@16.8.3",
+      "version": "16.8.3",
       "resolved": "https://registry.npmjs.org/vue-loader/-/vue-loader-16.8.3.tgz",
       "integrity": "sha512-7vKN45IxsKxe5GcVCbc2qFU5aWzyiLrYJyUuMz4BQLKctCj/fmCa0w6fGiiQ2cLFetNcek1ppGJQDCup0c1hpA==",
       "dev": true,

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "core-js": "^3.6.5",
     "lodash": "^4.17.21",
     "moment-timezone": "0.5.34",
+    "v-calendar": "2.3.4",
     "vue": "^2.6.11",
     "vue-class-component": "^7.2.3",
     "vue-moment": "4.1.0",

--- a/src/main.ts
+++ b/src/main.ts
@@ -8,6 +8,9 @@ import utils from './utils'
 import Vue from 'vue'
 import vuetify from './plugins/vuetify'
 
+import VCalendar from 'v-calendar'
+Vue.use(VCalendar, {componentPrefix: 'c'})
+
 import VueMoment from 'vue-moment'
 Vue.use(VueMoment, {moment})
 

--- a/tests/api/test_department_controller.py
+++ b/tests/api/test_department_controller.py
@@ -539,11 +539,12 @@ class TestEditEvaluationMultipleDepartments:
         assert history_eval['status'] == 'review'
         assert melc_eval['conflicts']['departmentForm'] == [{'department': 'History', 'value': 'HISTORY'}]
         assert melc_eval['conflicts']['evaluationType'] == [{'department': 'History', 'value': 'G'}]
-        assert melc_eval['conflicts']['startDate'] == [{'department': 'History', 'value': '2022-02-13'}]
+        # TODO remove back end for setting start dates
+        # assert melc_eval['conflicts']['startDate'] == [{'department': 'History', 'value': '2022-02-13'}]
         assert melc_eval['conflicts']['endDate'] == [{'department': 'History', 'value': '2022-05-02'}]
         assert history_eval['conflicts']['departmentForm'] == [{'department': 'Middle Eastern Languages and Cultures', 'value': 'MELC'}]
         assert history_eval['conflicts']['evaluationType'] == [{'department': 'Middle Eastern Languages and Cultures', 'value': 'F'}]
-        assert history_eval['conflicts']['startDate'] == [{'department': 'Middle Eastern Languages and Cultures', 'value': '2022-02-14'}]
+        # assert history_eval['conflicts']['startDate'] == [{'department': 'Middle Eastern Languages and Cultures', 'value': '2022-02-14'}]
         assert history_eval['conflicts']['endDate'] == [{'department': 'Middle Eastern Languages and Cultures', 'value': '2022-05-01'}]
 
 

--- a/tests/api/test_section_controller.py
+++ b/tests/api/test_section_controller.py
@@ -57,4 +57,5 @@ class TestGetSection:
             'instructionFormat': 'IND',
             'sectionNumber': '003',
             'courseTitle': 'Special Studies: Cuneiform',
+            'modular': False,
         }


### PR DESCRIPTION
https://jira-secure.berkeley.edu/browse/DAMIEN-192

Introduces the same v-calendar datepicker plugin used by Diablo.

`startDate` as an independent field is not yet wholly removed on the back end, in case we change our minds about wanting it gone.