### PR TITLE
DAMIEN-296: for x-listed sections, includes dept B's eval row in dept A's feed

### DIFF
--- a/damien/lib/queries.py
+++ b/damien/lib/queries.py
@@ -191,11 +191,12 @@ def get_cross_listings(term_id, course_numbers):
             AND ss.course_number = cl2.cross_listing_number
             ORDER BY ss.course_number, ss.instructor_uid
         """
+    params = {'term_id': term_id, 'course_numbers': course_numbers}
     results = db.session().execute(
         text(query),
-        {'term_id': term_id, 'course_numbers': course_numbers},
+        params,
     ).all()
-    app.logger.info(f'Unholy loch cross-listing query returned {len(results)} results: {query}')
+    app.logger.info(f'Unholy loch cross-listing query returned {len(results)} results: {query} {params}')
     return results
 
 
@@ -214,11 +215,12 @@ def get_room_shares(term_id, course_numbers):
             AND ss.course_number = cs2.room_share_number
             ORDER BY ss.course_number, ss.instructor_uid
         """
+    params = {'term_id': term_id, 'course_numbers': course_numbers}
     results = db.session().execute(
         text(query),
-        {'term_id': term_id, 'course_numbers': course_numbers},
+        params,
     ).all()
-    app.logger.info(f'Unholy loch room share query returned {len(results)} results: {query}')
+    app.logger.info(f'Unholy loch room share query returned {len(results)} results: {query} {params}')
     return results
 
 
@@ -287,11 +289,12 @@ def get_loch_sections_by_ids(term_id, course_numbers):
             WHERE s.term_id = :term_id AND s.course_number = ANY(:course_numbers)
             ORDER BY s.course_number, s.instructor_uid
         """
+    params = {'term_id': term_id, 'course_numbers': course_numbers}
     results = db.session().execute(
         text(query),
-        {'term_id': term_id, 'course_numbers': course_numbers},
+        params,
     ).all()
-    app.logger.info(f'Unholy loch course by id query returned {len(results)} results: {query}')
+    app.logger.info(f'Unholy loch course by id query returned {len(results)} results: {query} {params}')
     return results
 
 

--- a/damien/models/evaluation.py
+++ b/damien/models/evaluation.py
@@ -350,7 +350,7 @@ class Evaluation(Base):
         if saved_evaluation and saved_evaluation.department_form:
             self.department_form = saved_evaluation.department_form
             for fde in foreign_dept_evaluations:
-                if fde.department_form and fde.department_form != self.department_form:
+                if fde.department_form and fde.department_form.id != self.department_form.id:
                     self.mark_conflict(fde, 'departmentForm', saved_evaluation, self.department_form.name, fde.department_form.name)
         else:
             for fde in foreign_dept_evaluations:
@@ -364,7 +364,7 @@ class Evaluation(Base):
         if saved_evaluation and saved_evaluation.evaluation_type:
             self.evaluation_type = saved_evaluation.evaluation_type
             for fde in foreign_dept_evaluations:
-                if fde.evaluation_type and fde.evaluation_type != self.evaluation_type:
+                if fde.evaluation_type and fde.evaluation_type.id != self.evaluation_type.id:
                     self.mark_conflict(fde, 'evaluationType', saved_evaluation, self.evaluation_type.name, fde.evaluation_type.name)
         else:
             for fde in foreign_dept_evaluations:

--- a/tests/api/test_department_controller.py
+++ b/tests/api/test_department_controller.py
@@ -215,13 +215,12 @@ class TestGetDepartment:
         assert home_dept_row['roomSharedWith'] == ['32159']
         assert home_dept_row['departmentForm'] is None
 
-    def test_single_section_feed(self, client, fake_auth, melc_id, app):
+    def test_single_section_feed(self, client, fake_auth, melc_id):
         """Sorts section evalutions by type, then form, then instructor, then start date."""
         fake_auth.login(non_admin_uid)
         response = client.get(f'/api/department/{melc_id}/section_evaluations/30666')
         assert response.status_code == 200
         feed = response.json
-        app.logger.error(feed)
         assert len(feed) == 5
         assert feed[0]['courseNumber'] == '30666'
         assert feed[0]['evaluationType']['name'] == 'F'


### PR DESCRIPTION
https://jira-secure.berkeley.edu/browse/DAMIEN-299

With my changes,`merge_evaluations` exceeded lint-py's tolerance for complexity.