### PR TITLE
DAMIEN-313: prevents transient ids from being passed to query as ids

### DIFF
--- a/damien/api/department_controller.py
+++ b/damien/api/department_controller.py
@@ -167,7 +167,7 @@ def _validate_confirmable(evaluation_ids, fields=None):
         return True
     numeric_ids = [int(eid) for eid in evaluation_ids if re.match(r'\d+\Z', str(eid))]
     if numeric_ids:
-        validation_errors = Evaluation.get_invalid(app.config['CURRENT_TERM_ID'], evaluation_ids=evaluation_ids)
+        validation_errors = Evaluation.get_invalid(app.config['CURRENT_TERM_ID'], evaluation_ids=numeric_ids)
         if validation_errors:
             raise BadRequestError('Could not confirm evaluations with errors.')
 

--- a/src/components/evaluation/AddCourseSection.vue
+++ b/src/components/evaluation/AddCourseSection.vue
@@ -176,6 +176,8 @@ export default {
       this.alertScreenReader(`Adding section ${courseNumber}.`)
       this.addSection(courseNumber).then(() => {
         this.isAddingSection = false
+        this.courseNumber = null
+        this.section = null
         this.alertScreenReader(`Section ${courseNumber} added.`)
       }, error => this.showErrorDialog(error.response.data.message))
       .finally(() => this.setDisableControls(false))


### PR DESCRIPTION
https://jira-secure.berkeley.edu/browse/DAMIEN-313

I wasn't able to replicate the error, but somehow (according to logs) alphanumeric transient IDs were included in the `evaluationIds` list along with numeric IDs, causing the query error.

@pauline2k does this fix make sense to you?

I'm also fixing a bug in AddCourseSection.