### PR TITLE
DAMIEN-368 Allow null department form in evaluation edit

### DIFF
--- a/src/components/evaluation/EvaluationTable.vue
+++ b/src/components/evaluation/EvaluationTable.vue
@@ -706,7 +706,7 @@ export default {
     },
     saveEvaluation(evaluation) {
       const fields = {
-        'departmentFormId': this.selectedDepartmentForm || this.$_.get(evaluation, 'defaultDepartmentForm.id'),
+        'departmentFormId': this.selectedDepartmentForm || this.$_.get(evaluation, 'defaultDepartmentForm.id') || null,
         'evaluationTypeId': this.selectedEvaluationType,
         'instructorUid': this.$_.get(this.pendingInstructor, 'uid'),
         'status': this.selectedEvaluationStatus


### PR DESCRIPTION
https://jira-secure.berkeley.edu/browse/DAMIEN-368

Here's a fun teaching moment. Seems that something in our stack (axios?) silently strips out of the payload any POST params that evaluate to `undefined`. Setting them explicitly to `null` gets them through.