### PR TITLE
DAMIEN-406: relaxes conflict validation for unmarked rows

### DIFF
--- a/tests/api/test_department_controller.py
+++ b/tests/api/test_department_controller.py
@@ -365,31 +365,31 @@ class TestUpdateEvaluationStatus:
         # Try to confirm the two conflicting rows
         _api_update_evaluation(client, dept_id=dept.id, params={'evaluationIds': evaluation_ids, 'action': 'confirm'}, expected_status_code=400)
 
-        # Try to confirm the rows invidually
-        _api_update_evaluation(client, dept_id=dept.id, params={'evaluationIds': [evaluation_ids[0]], 'action': 'confirm'}, expected_status_code=400)
+        # Confirm the first row, then try to confirm the second row
+        _api_update_evaluation(client, dept_id=dept.id, params={'evaluationIds': [evaluation_ids[0]], 'action': 'confirm'})
         _api_update_evaluation(client, dept_id=dept.id, params={'evaluationIds': [evaluation_ids[1]], 'action': 'confirm'}, expected_status_code=400)
 
-        # Try to confirm while resolving some but not all conflicts
+        # Try to confirm the second row while resolving some but not all conflicts
         _api_update_evaluation(client, dept_id=dept.id, params={
-            'evaluationIds': [evaluation_ids[0]],
-            'fields': {'departmentFormId': form_history_id, 'status': 'confirmed'},
+            'evaluationIds': [evaluation_ids[1]],
+            'fields': {'departmentFormId': form_melc_id, 'status': 'confirmed'},
             'action': 'edit',
         }, expected_status_code=400)
         _api_update_evaluation(client, dept_id=dept.id, params={
-            'evaluationIds': [evaluation_ids[0]],
-            'fields': {'departmentFormId': form_history_id, 'startDate': '2022-04-15', 'status': 'confirmed'},
+            'evaluationIds': [evaluation_ids[1]],
+            'fields': {'startDate': '2022-03-15', 'status': 'confirmed'},
             'action': 'edit',
         }, expected_status_code=400)
         _api_update_evaluation(client, dept_id=dept.id, params={
-            'evaluationIds': [evaluation_ids[0]],
-            'fields': {'departmentFormId': form_history_id, 'evaluationTypeId': type_g_id, 'status': 'confirmed'},
+            'evaluationIds': [evaluation_ids[1]],
+            'fields': {'evaluationTypeId': type_f_id, 'status': 'confirmed'},
             'action': 'edit',
         }, expected_status_code=400)
 
-        # Resolve all conflicts and evaluation succeeds
+        # Resolve all conflicts and confirm succeeds
         _api_update_evaluation(client, dept_id=dept.id, params={
-            'evaluationIds': [evaluation_ids[0]],
-            'fields': {'departmentFormId': form_history_id, 'evaluationTypeId': type_g_id, 'startDate': '2022-04-15', 'status': 'confirmed'},
+            'evaluationIds': [evaluation_ids[1]],
+            'fields': {'departmentFormId': form_melc_id, 'evaluationTypeId': type_f_id, 'startDate': '2022-03-15', 'status': 'confirmed'},
             'action': 'edit',
         })
 

--- a/tox.ini
+++ b/tox.ini
@@ -30,7 +30,7 @@ commands = pytest {posargs: -p no:warnings tests}
 # Bottom of file has Flake8 settings
 commands = flake8 {posargs:application.py config consoler.py damien scripts tests mrsbaylock}
 deps =
-    flake8>=4.0.1
+    flake8==4.0.1
     flake8-builtins>=1.5.3
     flake8-colors>=0.1.9
     flake8-commas>=2.1.0


### PR DESCRIPTION
When a department has multiple rows for the same course and instructor with different eval type, dept form, or start date, only rows marked To-Do or Done will be flagged as a conflict (and only when 2 or more of the rows are marked as such).