### PR TITLE
DAMIEN-422: exempts midterm evals from conflict detection

### DIFF
--- a/damien/merged/section.py
+++ b/damien/merged/section.py
@@ -60,6 +60,22 @@ class Section:
         self.set_cross_listed_status(loch_rows)
         self.set_defaults(catalog_listings, evaluation_types)
 
+    def __repr__(self):
+        return f"""<Section term_id={self.term_id},
+                    course_number={self.course_number},
+                    subject_area={self.subject_area},
+                    catalog_id={self.catalog_id},
+                    instruction_format={self.instruction_format},
+                    section_num={self.section_num},
+                    course_title={self.course_title},
+                    is_primary={self.is_primary},
+                    start_date={self.start_date},
+                    end_date={self.end_date},
+                    default_evaluation_types={self.default_evaluation_types},
+                    default_form={self.default_form},
+                    foreign_department_course={self.foreign_department_course}>
+                """
+
     @classmethod
     def is_visible_by_default(cls, loch_row):
         return (

--- a/damien/models/department_form.py
+++ b/damien/models/department_form.py
@@ -54,7 +54,8 @@ class DepartmentForm(Base):
 
     def __repr__(self):
         return f"""<DepartmentForm id={self.id},
-                    name={self.name}>
+                    name={self.name},
+                    deleted_at={self.deleted_at}>
                 """
 
     @classmethod

--- a/tests/api/test_evaluation_controller.py
+++ b/tests/api/test_evaluation_controller.py
@@ -254,8 +254,10 @@ class TestExportEvaluations:
     def test_confirmed_course(self, client, app, fake_auth, history_id, form_history_id, type_f_id):
         fake_auth.login(admin_uid)
         _api_update_history_evaluation(client, history_id, form_history_id, type_f_id)
+        std_commit(allow_test_environment=True)
         evaluation = _api_get_evaluation(client, history_id, '30643', '326054')
         _api_update_evaluation(client, history_id, params={'evaluationIds': [evaluation['id']], 'action': 'confirm'})
+        std_commit(allow_test_environment=True)
 
         with mock_s3_bucket(app) as s3:
             _api_export_evaluations(client)


### PR DESCRIPTION
https://jira-secure.berkeley.edu/browse/DAMIEN-422

Also, when comparing two evals the logic will fill in empty fields with their default values whenever possible.