### PR TITLE
DAMIEN-468 Fix indentation blunder in export loop

### DIFF
--- a/damien/lib/exporter.py
+++ b/damien/lib/exporter.py
@@ -191,7 +191,7 @@ def _generate_course_id_map(keys, course_number, term_id):
         course_id_map = {}
         for index, key in enumerate(keys):
             postfix = '' if index == 0 else f'_{chr(64 + index)}'
-        course_id_map[key] = f'{course_id_prefix}{postfix}'
+            course_id_map[key] = f'{course_id_prefix}{postfix}'
         return course_id_map
 
 


### PR DESCRIPTION
https://jira-secure.berkeley.edu/browse/DAMIEN-468

This particular scoping behavior (that `key` remains in scope even though yours truly referred to it after the end of the loop, like a bonehead) is one of the few things I actively dislike about Python.