### PR TITLE
DAMIEN-489: ignores foreign dept's evals marked Ignore

### DIFF
--- a/damien/merged/section.py
+++ b/damien/merged/section.py
@@ -173,6 +173,8 @@ class Section:
 
                 if evaluation.department == department:
                     home_dept_evals.append(evaluation)
+                elif evaluation.status == 'ignore':
+                    continue
                 elif evaluation.is_midterm():
                     foreign_dept_evals_midterm.append(evaluation)
                 else:

--- a/src/components/admin/PersonLookup.vue
+++ b/src/components/admin/PersonLookup.vue
@@ -25,7 +25,7 @@
       return-object
       :search-input.sync="search"
       single-line
-      @blur="validate(selected)"
+      @blur="onBlur"
     >
       <template #selection>
         <span class="text-nowrap">{{ toLabel(selected) }}</span>
@@ -122,6 +122,11 @@ export default {
       } else {
         this.searchTokenMatcher = null
         this.suggestions = []
+      }
+    },
+    onBlur() {
+      if (!this.isSearching && this.suggestions.length && !this.selected) {
+        this.selected = this.suggestions[0]
       }
     },
     suggest(user) {


### PR DESCRIPTION
https://jira-secure.berkeley.edu/browse/DAMIEN-489

Also auto-selects first item in person lookup if nothing selected (this slightly mitigates the problem of pasting in a UID and then moving on without selecting the suggested result).