### PR TITLE
DAMIEN-493: skips sections query for depts with no catalog listings in a term

### DIFF
--- a/damien/lib/queries.py
+++ b/damien/lib/queries.py
@@ -266,10 +266,10 @@ def get_loch_sections(term_id, conditions):
                 cs.room_share_number AS room_shared_with
             FROM unholy_loch.sis_sections s
             LEFT JOIN unholy_loch.cross_listings cl
-                ON cl.term_id = :term_id AND s.term_id = :term_id
+                ON cl.term_id = s.term_id
                 AND s.course_number = cl.course_number
             LEFT JOIN unholy_loch.co_schedulings cs
-                ON cs.term_id = :term_id AND s.term_id = :term_id
+                ON cs.term_id = s.term_id
                 AND s.course_number = cs.course_number
             WHERE s.term_id = :term_id AND ({' OR '.join(conditions)})
             ORDER BY s.course_number, s.instructor_uid

--- a/damien/models/department.py
+++ b/damien/models/department.py
@@ -141,6 +141,8 @@ class Department(Base):
             else:
                 subconditions.append(f"s.catalog_id SIMILAR TO '({'|'.join(catalog_ids)})'")
             conditions.append(f"({' AND '.join(subconditions)})")
+        if not conditions:
+            return []
         sections = get_loch_sections(term_id, conditions)
         self.merge_cross_listings(sections, term_id)
         return sorted(sections, key=lambda r: r['course_number'])


### PR DESCRIPTION
https://jira-secure.berkeley.edu/browse/DAMIEN-493

Also some cleanup on a query.