### PR TITLE
DAMIEN-626, AWS wants only major version of Node in buildspec

### DIFF
--- a/buildspec.yml
+++ b/buildspec.yml
@@ -3,7 +3,7 @@ version: 0.2
 phases:
   install:
     runtime-versions:
-      nodejs: 20.16.0
+      nodejs: 20
       python: 3.11
     commands:
       - echo -e '@neverendingsupport:registry=https://registry.nes.herodevs.com/npm/pkg/\n//registry.nes.herodevs.com/npm/pkg/:_authToken="'${NES_AUTH_TOKEN}'"' > .npmrc


### PR DESCRIPTION
https://jira-secure.berkeley.edu/browse/DAMIEN-626

You do not need to wait for Travis success cuz it's only buildspec change.