### PR TITLE
DAMIEN-703: fixes error in API call to refresh sections

### DIFF
--- a/src/components/evaluation/EvaluationActions.vue
+++ b/src/components/evaluation/EvaluationActions.vue
@@ -151,7 +151,6 @@ onMounted(() => {
       apply: onClickReview,
       completedText: 'Marked as to-do',
       inProgressText: 'Marking as to-do',
-      key: 'review',
       status: 'review',
       text: 'Mark as to-do'
     },
@@ -159,7 +158,6 @@ onMounted(() => {
       apply: onClickMarkDone,
       completedText: 'Marked as done',
       inProgressText: 'Marking as done',
-      key: 'confirm',
       status: 'confirmed',
       text: 'Mark as done'
     },
@@ -167,7 +165,6 @@ onMounted(() => {
       apply: onClickUnmark,
       completedText: 'Unmarked',
       inProgressText: 'Unmarking',
-      key: 'unmark',
       status: null,
       text: 'Unmark'
     },
@@ -175,7 +172,6 @@ onMounted(() => {
       apply: onClickIgnore,
       completedText: 'Ignored',
       inProgressText: 'Ignoring',
-      key: 'ignore',
       status: 'ignore',
       text: 'Ignore'
     },
@@ -183,7 +179,6 @@ onMounted(() => {
       apply: onClickDuplicate,
       completedText: 'Duplicated',
       inProgressText: 'Duplicating',
-      key: 'duplicate',
       text: 'Duplicate'
     },
     edit: {
@@ -360,7 +355,7 @@ const update = (fields, key) => {
     .map(e => e.courseNumber))
   const refresh = () => {
     return selectedCourseNumbers.length === 1
-      ? departmentStore.refreshSection({sectionId: selectedCourseNumbers[0], termId: useContextStore().selectedTermId})
+      ? departmentStore.refreshSection(selectedCourseNumbers[0], useContextStore().selectedTermId)
       : departmentStore.refreshAll()
   }
   updateEvaluations(

--- a/src/components/evaluation/EvaluationTable.vue
+++ b/src/components/evaluation/EvaluationTable.vue
@@ -38,6 +38,7 @@
               :indeterminate="someEvaluationsSelected"
               :input-value="someEvaluationsSelected || allEvaluationsSelected"
               :model-value="allEvaluationsSelected"
+              :ripple="false"
               @change="toggleSelectAll"
             >
               <template #label>
@@ -177,6 +178,7 @@
                   :disabled="editRowId === evaluation.id"
                   hide-details
                   :model-value="evaluation.isSelected"
+                  :ripple="false"
                   @update:model-value="() => departmentStore.toggleSelectEvaluation(evaluation)"
                 />
               </td>


### PR DESCRIPTION
https://jira-secure.berkeley.edu/browse/DAMIEN-703

I also disabled the ripple animation on checkboxes in the evaluations table for performance reasons (this was disabled in the Vue2 version as well).