### PR TITLE
DAMIEN-727 - Fix Select All Checkbox (remove indeterminate state)

### DIFF
--- a/src/components/evaluation/EvaluationTable.vue
+++ b/src/components/evaluation/EvaluationTable.vue
@@ -33,10 +33,7 @@
               color="tertiary"
               density="compact"
               :disabled="!searchFilterResults.length"
-              :false-value="!someEvaluationsSelected && !allEvaluationsSelected"
               hide-details
-              :indeterminate="someEvaluationsSelected"
-              :input-value="someEvaluationsSelected || allEvaluationsSelected"
               :model-value="allEvaluationsSelected"
               :ripple="false"
               @change="toggleSelectAll"
@@ -859,7 +856,7 @@ const selectInstructor = instructor => {
 }
 
 const toggleSelectAll = () => {
-  if (allEvaluationsSelected.value || someEvaluationsSelected.value) {
+  if (allEvaluationsSelected.value) {
     departmentStore.deselectAllEvaluations()
     alertScreenReader('All evaluations unselected')
   } else {


### PR DESCRIPTION
Jira: https://jira-secure.berkeley.edu/browse/DAMIEN-727

This most likely appears to be a Vuetify 3 bug with the indeterminate state. 

On the vuetify v-checkbox page https://vuetifyjs.com/en/components/checkboxes/#states - Once a user clicks on a v-checkbox that it is indeterminate, it then gets selected instead of unselected. There appears to beno way around this. Both allEvaluationsSelected and someEvaluationsSelected in the code were false, yet the checkbox remain selected. 

So to fix this, I removed the indeterminate state, leaving the checkbox with the standard true/false states