### PR TITLE
DAMIEN-892: Merge beanstalk and custom cloudwatch agent config

### DIFF
--- a/.platform/hooks/postdeploy/01_start_awslogsd.sh
+++ b/.platform/hooks/postdeploy/01_start_awslogsd.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-sudo /opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl -a fetch-config -m ec2 -c file:/tmp/amazon-cloudwatch-agent.json -s
+sudo /opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl -a append-config -m ec2 -c file:/tmp/amazon-cloudwatch-agent.json -s


### PR DESCRIPTION
The fetch-config post hook is not merging beanstalk provided config and our custom cloudwatch config in a way that reliably streams all logs we need. The 'append-config' amazon-cloudwatch-agent-ctl  argument is the proper way to handle this.